### PR TITLE
Use log crate

### DIFF
--- a/remote-trait-object-tests/Cargo.toml
+++ b/remote-trait-object-tests/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 [dependencies]
 crossbeam = "0.7.3"
+env_logger = "0.7.1"
+log = "0.4.8"
 remote-trait-object = {path = "../remote-trait-object"}
 parking_lot = "0.10.2"
 

--- a/remote-trait-object-tests/src/lib.rs
+++ b/remote-trait-object-tests/src/lib.rs
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(test)]
+#[macro_use]
+extern crate log;
+
 mod connection;
 mod mod_main;
 mod mod_ping;

--- a/remote-trait-object-tests/src/test_ping.rs
+++ b/remote-trait-object-tests/src/test_ping.rs
@@ -18,6 +18,10 @@ use super::mod_main::main_like as main_main;
 use super::mod_ping::main_like as ping_main;
 use crate::connection::{create_connection, ConnectionEnd};
 
+fn init_logger() {
+    let _ = env_logger::builder().is_test(true).try_init();
+}
+
 /// There are thee entities: commander, main module and ping module.
 /// Commander sends "start" message to the main module.
 /// If the main module receives "start" message, it sends "ping" to the ping module.
@@ -25,16 +29,15 @@ use crate::connection::{create_connection, ConnectionEnd};
 /// If the main module received "pong" response, send "pong received" to the commander.
 #[test]
 fn ping() {
-    // FIXME: use a logger
-    println!("ping test start");
+    init_logger();
+
+    debug!("ping test start");
     let (main_to_cmd, cmd_to_main) = create_connection();
     let (main_to_ping, ping_to_main) = create_connection();
 
-    // FIXME: use a logger
-    println!("Call main_main");
+    debug!("Call main_main");
     let _main_module = main_main(Vec::new(), main_to_cmd, main_to_ping);
-    // FIXME: use a logger
-    println!("Call ping_main");
+    debug!("Call ping_main");
     let _ping_module = ping_main(Vec::new(), ping_to_main);
 
     let ConnectionEnd {
@@ -42,13 +45,10 @@ fn ping() {
         receiver: from_main,
     } = cmd_to_main;
 
-    // FIXME: use a logger
-    println!("Send start cmd");
+    debug!("Send start cmd");
     to_main.send("request:start".to_string()).unwrap();
-    // FIXME: use a logger
-    println!("Recv pong response");
+    debug!("Recv pong response");
     let response = from_main.recv().unwrap();
     assert_eq!(response, "response:pong received".to_string());
-    // FIXME: use a logger
-    println!("Test finished");
+    debug!("Test finished");
 }

--- a/remote-trait-object/Cargo.toml
+++ b/remote-trait-object/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 
 [dependencies]
 crossbeam = "0.7.3"
+log = "0.4.8"

--- a/remote-trait-object/src/ipc/multiplex.rs
+++ b/remote-trait-object/src/ipc/multiplex.rs
@@ -41,8 +41,7 @@ impl Multiplexer {
                     recv(ipc_recv) -> msg => match msg {
                         Ok(msg) => msg,
                         Err(err) => {
-                            // FIXME: use a logger
-                            println!("ipc_recv is closed in multiplex {}", err);
+                            debug!("ipc_recv is closed in multiplex {}", err);
                             return;
                         }
                     },

--- a/remote-trait-object/src/lib.rs
+++ b/remote-trait-object/src/lib.rs
@@ -16,6 +16,8 @@
 
 #[macro_use]
 extern crate crossbeam;
+#[macro_use]
+extern crate log;
 
 mod ipc;
 mod port;


### PR DESCRIPTION
We can print logs in the test using the command below:
`RUST_LOG=trace cargo test --all -- --nocapture`

I will make libraries use only the `log` library. Only remote-trait-object-tests will have `env_logger` crate.
If a library uses `log` crate, an application that uses the library can choose log implementation. `env_logger` is one of the log implementation crates.

You can check detailed instruction in the `log` crate's documentation: https://docs.rs/log/0.4.8/log/

